### PR TITLE
Local server

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -25,7 +25,11 @@ var server = http.createServer(app);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
+var host = '';
+if(process.argv[2] === "local"){
+    host = 'localhost';
+}
+server.listen(port, host);
 server.on('error', onError);
 server.on('listening', onListening);
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "start-local": "node ./bin/www local"
   },
   "dependencies": {
     "body-parser": "^1.18.2",


### PR DESCRIPTION
Add local option to start server listening on localhost only.
If you run `node bin/www local` the server will only respond to requests from `localhost`.
The behaviour of `node bin/www` is unchanged. For convenience I also added the command to `package.json` so `npm start-local` will start the server locally as well.