### PR TITLE
Local server

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www",
-    "start-local": "node ./bin/www local"
+    "start": "node ./bin/www"
   },
   "dependencies": {
     "body-parser": "^1.18.2",


### PR DESCRIPTION
Remove `start-local` script from `package.json`.
Sorry for the confusion here: I added this script and actually tested with `yarn` instead of `npm`.
And while `yarn start-local` works `npm start-local` does not. Instead you would have to call `npm run-script start-local`. However, as `npm start local` works by passing the parameter `local` on to the start script this separate command is not required at all.